### PR TITLE
Fixed incompatible pointer type in btusb.c

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -1696,7 +1696,7 @@ MODULE_PARM_DESC(disable_scofix, "Disable fixup of wrong SCO buffer size");
 module_param(force_scofix, bool, 0644);
 MODULE_PARM_DESC(force_scofix, "Force fixup of wrong SCO buffers size");
 
-module_param(reset, bool, 0644);
+module_param(reset, int, 0644);
 MODULE_PARM_DESC(reset, "Send HCI reset command on initialization");
 
 MODULE_AUTHOR("Marcel Holtmann <marcel@holtmann.org>");


### PR DESCRIPTION
Compiling with the HCI USB Driver enabled failed due to an incompatible pointer type used in the `module_param` call in `btusb.c`. This commit corrects that issue. 
Make fails with the driver enabled, throwing:
```
drivers/bluetooth/btusb.c: 
In function '__check_reset':  
include/linux/moduleparam.h:338:45: warning: return from incompatible pointer type error
```